### PR TITLE
Add scrape_recent_posts method and tests.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,12 @@ Features
 * Retrieve sentiment for posts
 * Search threads & posts
 
+My current thinking is that if I just repeatedly scrape the recent posts page (https://teslamotorsclub.com/tmc/recent-posts/), that will provide the sufficient data to inform every other view (i.e. search by thread/poster/sentiment/keyword/etc.) in a database format.
 
+Open questions:
+
+- how to handle deleted/edited posts?
+- database layer to use? leaning towards MySQL
 
 Credits
 -------

--- a/tests/test_tmc.py
+++ b/tests/test_tmc.py
@@ -65,3 +65,10 @@ def test_message_get_sentiment():
     post = forum_scraper.scrape_post_by_id(post_id=3507092)
     post.get_sentiment()
     assert post.sentiment['label'] == 'neg'
+
+
+def test_scrape_recent_posts():
+    forum_scraper = ForumScraper()
+    recent_posts = forum_scraper.scrape_recent_posts(pages=2)
+    assert len(recent_posts) == 50
+

--- a/tmc/forum_scraper.py
+++ b/tmc/forum_scraper.py
@@ -113,7 +113,7 @@ class ForumScraper:
         else:
             return 1
 
-    def scrape_recent_posts(self):
+    def scrape_recent_posts(self, pages: int = 10):
         """
         Scrapes most recent posts as shown by https://teslamotorsclub.com/tmc/recent-posts/
         and returns post objects for each new post.
@@ -123,7 +123,7 @@ class ForumScraper:
 
         recent_posts = []
 
-        for page_number in range(1, 11):
+        for page_number in range(1, pages):
             recent_posts_url = url + f'?page={page_number}'
             response = self.session.get(recent_posts_url)
 
@@ -138,7 +138,7 @@ class ForumScraper:
                 parsed_post = Post(targeted_post)
                 recent_posts.append(parsed_post)
 
-        return
+        return recent_posts
 
     def scrape_post_by_id(self, post_id: int = 0, thread_id: str = None):
         """


### PR DESCRIPTION
I plan on starting to implement actual database read/writing into this project in the future, and in order to do that we (in part) needed a method that would grab the most recent posts as defined by the TMC forum. There will be some updates in the future regarding checking if post X is already in the database and if so, end the search.